### PR TITLE
Change name reported by bin/detect to "Python TA-Lib"

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -7,4 +7,4 @@ if [ ! -f $BUILD_DIR/requirements.txt ] && [ ! -f $BUILD_DIR/setup.py ] && [ ! -
   exit 1
 fi
 
-echo Python
+echo "Python TA-Lib"


### PR DESCRIPTION
Since currently it outputs "Python", which results in the detected buildpack name being the same as the Python buildpack this is used alongside.

Changing this to a unique name makes the build output easier to debug, since it means the log sections more clearly map back to each buildpack.

Before:

```
-----> Python app detected
...
-----> Python app detected
...
```

After:

```
-----> Python app detected
...
-----> Python TA-Lib app detected
...
```