### PR TITLE
Specify wrapper version 0.5.1 to maintain compatibility with 0.4.0 Core C-library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Yevhen
+Copyright (c) 2024 t-shah
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,16 +1,54 @@
-# Heroku Python TA-Lib package
+# Heroku Buildpack: Python + TA-Lib
 
-This buildpack should be used in conjunction with the [official Heroku Python buildpack](https://github.com/heroku/heroku-buildpack-python).
+This buildpack installs the [TA-Lib C library](https://ta-lib.org/) and the corresponding Python wrapper for technical analysis in financial applications.
+
+## Usage
+
+This buildpack should be used in conjunction with the [official Heroku Python buildpack](https://github.com/heroku/heroku-buildpack-python). Ensure the Python buildpack is listed first.
 
 ```
 ~ $ heroku buildpacks:add --index 1 heroku/python
-~ $ heroku buildpacks:add --index 2 numrut/ta-lib
+~ $ heroku buildpacks:add --index 2 https://github.com/t-shah/heroku-buildpack-python-talib.git
 ```
 
-## Using the latest buildpack code
+- **Do not include TA-Lib in requirements.txt.**
+  - The buildpack installs the TA-Lib Python wrapper automatically.
 
-The `numrut/ta-lib` buildpack from the [Heroku Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry) contains the latest stable version of the buildpack. If you'd like to use the latest buildpack code from this Github repository, you can set your buildpack to the Github URL:
+## Debugging
 
-```
-~ $ heroku buildpacks:add --index 2 https://github.com/numrut/heroku-buildpack-python-talib
-```
+If the build fails, check the logs for detailed error messages:
+
+- **Common issues:**
+  - Missing build tools (`gcc`, `make`).
+  - Network issues during source code download.
+ 
+## Configuration
+
+- **Installation directory:** The buildpack installs TA-Lib to `/app/.heroku/vendor/ta-lib`.
+- **Environment variables:**
+  - `LD_LIBRARY_PATH`: Ensures the linker can locate `libta_lib.so`.
+  - `CFLAGS`: Points to the TA-Lib headers.
+
+## Compatibility
+
+- **Heroku stacks:**
+  - `heroku-20`
+  - `heroku-22`
+- **Python versions:**
+  - Compatible with Python 3.7 - 3.10.
+
+## Troubleshooting
+
+1. **Build Errors:**
+   - Check the output of `./configure`, `make`, and `make install` for issues.
+   - Ensure that `requirements.txt` excludes `TA-Lib`.
+
+2. **Library Not Found:**
+   - Verify that `libta_lib.so` exists in `/app/.heroku/vendor/ta-lib/lib`.
+
+3. **Python Version Compatibility:**
+   - Confirm the Python version used by your app matches the supported versions for TA-Lib.
+
+## Contributions
+
+Feel free to open an issue or PR to improve this buildpack!

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ if [ "$TALIB" -eq "0" ]; then
 
   puts-step "Installing TA-Lib library source code"
   echo "Download & unpack..." | indent
-  wget -q http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz > /dev/null 2>&1
+  wget -q https://github.com/TA-Lib/ta-lib/releases/download/v0.4.0/ta-lib-0.4.0-src.tar.gz > /dev/null 2>&1
   tar -xf ta-lib-0.4.0-src.tar.gz  && cd ta-lib > /dev/null 2>&1
   echo "Compile..." | indent
   ./configure --includedir=/app/.heroku/python/include/${PYTHON} --libdir=/app/.heroku/python/lib --bindir=/app/.heroku/python/bin > /dev/null 2>&1

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ if [ "$TALIB" -eq "0" ]; then
   make install > /dev/null 2>&1
   echo "TA-Lib library successfully installed" | indent
 
-  /app/.heroku/python/bin/pip install TA-Lib 2>&1 | cleanup | indent
+  /app/.heroku/python/bin/pip install TA-Lib==0.5.1 2>&1 | cleanup | indent
 
   rm -rf $CACHE_DIR/.heroku/python/
   cp -R /app/.heroku/python/ $CACHE_DIR/.heroku/


### PR DESCRIPTION
To manage compatibility with C-library source code and Python wrapper:

Core C-library 0.6.1 goes with wrapper 0.5.2+ OR C-library 0.4.0 goes with wrapper 0.5.1 (until wrapper is made to be backwards compatible)

Specifying wrapper version 0.5.1 in compile script.