### PR TITLE
Specify wrapper version 0.5.1 to maintain compatibility with 0.4.0 Core C-library

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ if [ "$TALIB" -eq "0" ]; then
 
   puts-step "Installing TA-Lib library source code"
   echo "Download & unpack..." | indent
-  wget -q http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz > /dev/null 2>&1
+  wget -q https://github.com/TA-Lib/ta-lib/releases/download/v0.4.0/ta-lib-0.4.0-src.tar.gz > /dev/null 2>&1
   tar -xf ta-lib-0.4.0-src.tar.gz  && cd ta-lib > /dev/null 2>&1
   echo "Compile..." | indent
   ./configure --includedir=/app/.heroku/python/include/${PYTHON} --libdir=/app/.heroku/python/lib --bindir=/app/.heroku/python/bin > /dev/null 2>&1

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ if [ "$TALIB" -eq "0" ]; then
   make install > /dev/null 2>&1
   echo "TA-Lib library successfully installed" | indent
 
-  /app/.heroku/python/bin/pip install TA-Lib 2>&1 | cleanup | indent
+  /app/.heroku/python/bin/pip install TA-Lib==0.5.1 2>&1 | cleanup | indent
 
   rm -rf $CACHE_DIR/.heroku/python/
   cp -R /app/.heroku/python/ $CACHE_DIR/.heroku/


### PR DESCRIPTION
To manage compatibility with C-library source code and Python wrapper:

1. Specifying wrapper version 0.5.1 in compile script.
2. Updating source location of Core C-library from Sourceforge to Github (new official location for TA_Lib)

Core C-library 0.6.1 goes with wrapper 0.5.2+ OR C-library 0.4.0 goes with wrapper 0.5.1 (until wrapper is made to be backwards compatible)

