### PR TITLE
Bump TA-Lib versioning

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,8 +13,8 @@ if [ "$TALIB" -eq "0" ]; then
 
   puts-step "Installing TA-Lib library source code"
   echo "Download & unpack..." | indent
-  wget -q https://github.com/TA-Lib/ta-lib/releases/download/v0.4.0/ta-lib-0.4.0-src.tar.gz > /dev/null 2>&1
-  tar -xf ta-lib-0.4.0-src.tar.gz  && cd ta-lib > /dev/null 2>&1
+  wget -q https://github.com/TA-Lib/ta-lib/releases/download/v0.6.3/ta-lib-0.6.3-src.tar.gz > /dev/null 2>&1
+  tar -xf ta-lib-0.6.3-src.tar.gz  && cd ta-lib > /dev/null 2>&1
   echo "Compile..." | indent
   ./configure --includedir=/app/.heroku/python/include/${PYTHON} --libdir=/app/.heroku/python/lib --bindir=/app/.heroku/python/bin > /dev/null 2>&1
   make > /dev/null 2>&1
@@ -22,7 +22,7 @@ if [ "$TALIB" -eq "0" ]; then
   make install > /dev/null 2>&1
   echo "TA-Lib library successfully installed" | indent
 
-  /app/.heroku/python/bin/pip install TA-Lib==0.5.1 2>&1 | cleanup | indent
+  /app/.heroku/python/bin/pip install TA-Lib==0.6.3 2>&1 | cleanup | indent
 
   rm -rf $CACHE_DIR/.heroku/python/
   cp -R /app/.heroku/python/ $CACHE_DIR/.heroku/


### PR DESCRIPTION
As seen [here](https://github.com/TA-Lib/ta-lib-python/releases/tag/TA_Lib-0.6.3) in TA-Lib python's official wrapper, the current stable version of TA-Lib is 0.6.3. Would be nice if the Heroku buildpack is able to accomodate the same :) 